### PR TITLE
Fix admin being able to see demote button

### DIFF
--- a/components/admin/admin-roster-table.tsx
+++ b/components/admin/admin-roster-table.tsx
@@ -204,18 +204,20 @@ export function AdminRosterTable({ admins, isOwner }: { admins: Admin[]; isOwner
                           View Availability
                         </DropdownMenuItem>
 
-                        <DropdownMenuItem
-                          variant="destructive"
-                          disabled={isPending}
-                          onSelect={(event) => {
-                            event.preventDefault();
-                            setPendingRemovalAdmin(admin);
-                          }}
-                        >
-                          {isPending && removingAdminId === admin.user_id
-                            ? "Demoting..."
-                            : "Demote Admin"}
-                        </DropdownMenuItem>
+                        {isOwner && (
+                          <DropdownMenuItem
+                            variant="destructive"
+                            disabled={isPending}
+                            onSelect={(event) => {
+                              event.preventDefault();
+                              setPendingRemovalAdmin(admin);
+                            }}
+                          >
+                            {isPending && removingAdminId === admin.user_id
+                              ? "Demoting..."
+                              : "Demote Admin"}
+                          </DropdownMenuItem>
+                        )}
                       </DropdownMenuContent>
                     </DropdownMenu>
                   </TableCell>


### PR DESCRIPTION
Changes:

- admin can no longer see demote button on admin roster