### PR TITLE
fixed ability to change room for inperson groups

### DIFF
--- a/app/admin/groups/page.tsx
+++ b/app/admin/groups/page.tsx
@@ -55,6 +55,16 @@ export default async function AdminGroupsPage() {
     `,
     )
     .order("created_at", { ascending: false });
+  // fetch all rooms for the dropdown when creating/editing groups
+  const { data: rooms, error: roomsError } = await supabase
+    .from("room")
+    .select("id, building, room_number")
+    .order("building", { ascending: true })
+    .order("room_number", { ascending: true });
+
+  if (roomsError) {
+    console.error("Failed to fetch rooms:", roomsError.message);
+  }
 
   const { data: studentProfiles, error: studentProfilesError } = await supabase
     .from("profile")
@@ -111,6 +121,7 @@ export default async function AdminGroupsPage() {
     <div className="w-full max-w-7xl space-y-2">
       <AdminGroupsClient
         groups={groups ?? []}
+        rooms={rooms ?? []}
         ungroupedStudents={ungroupedStudents}
         independentStudents={independentStudents}
       />

--- a/components/admin/admin-groups-client.tsx
+++ b/components/admin/admin-groups-client.tsx
@@ -148,11 +148,19 @@ type UngroupedStudent = {
   profile_picture_url: string | null;
 };
 
+
+type RoomOption = {
+  id: number;
+  building: string | null;
+  room_number: string | null;
+};
+
 type CreateGroupFormState = {
   dayOfWeek: number;
   meetStartTime: string;
   preference: GroupPreference;
   studentIds: string[];
+  roomId?: number | null;
 };
 
 type StudentSelectOption = UngroupedStudent & {
@@ -273,15 +281,18 @@ function getDefaultCreateFormState(): CreateGroupFormState {
     meetStartTime: `${GROUP_TIME_OPTIONS[0]}:00`,
     preference: "in_person",
     studentIds: [],
+    roomId: null,
   };
 }
 
 export default function AdminGroupsClient({
   groups,
+  rooms,
   ungroupedStudents,
   independentStudents,
 }: {
   groups: Group[];
+  rooms: RoomOption[];
   ungroupedStudents: UngroupedStudent[];
   independentStudents: UngroupedStudent[];
 }) {
@@ -474,6 +485,7 @@ export default function AdminGroupsClient({
       meetStartTime: group.meet_start_time,
       preference: (group.preference ?? "in_person") as GroupPreference,
       studentIds: group.member_of.map((member) => member.user_id),
+      roomId: group.room_id ?? null,
     });
     setEditGroupOpen(true);
   }
@@ -630,6 +642,7 @@ export default function AdminGroupsClient({
         meetEndTime: editMeeting.meetEndTime,
         preference: editForm.preference,
         studentIds: editForm.studentIds,
+        roomId: editForm.preference === "in_person" ? editForm.roomId : null,
         overrideWarnings,
       });
 
@@ -987,10 +1000,12 @@ export default function AdminGroupsClient({
             value={editForm.preference}
             disabled={updatingGroup}
             onChange={(event) => {
+              const nextPreference = event.target.value as GroupPreference;
               setEditWarnings([]);
               setEditForm((current) => ({
                 ...current,
-                preference: event.target.value as GroupPreference,
+                preference: nextPreference,
+                roomId: nextPreference === "online" ? null : current.roomId,
               }));
             }}
           >
@@ -998,6 +1013,35 @@ export default function AdminGroupsClient({
             <option value="online">Online</option>
           </select>
         </div>
+
+        {editForm.preference === "in_person" ? (
+          <div className="space-y-2">
+            <Label htmlFor="edit-group-room">Room</Label>
+            <select
+              id="edit-group-room"
+              className={FIELD_CLASSNAME}
+              value={editForm.roomId ?? ""}
+              disabled={updatingGroup}
+              onChange={(event) => {
+                setEditWarnings([]);
+                setEditForm((current) => ({
+                  ...current,
+                  roomId: event.target.value ? Number(event.target.value) : null,
+                }));
+              }}
+            >
+              <option value="">Auto assign room</option>
+              {rooms.map((room) => (
+                <option key={room.id} value={room.id}>
+                  {room.building ?? "Unknown"} {room.room_number ?? ""}
+                </option>
+              ))}
+            </select>
+            <p className="text-muted-foreground text-sm">
+              Choose a specific room for this in-person group, or leave blank to let the system automatically assign one.
+            </p>
+          </div>
+        ) : null}
 
         <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
           <p className="font-medium">Meeting preview</p>

--- a/lib/actions/admin-actions.ts
+++ b/lib/actions/admin-actions.ts
@@ -924,21 +924,46 @@ export async function updateManualGroup(
       return existingUsageResult;
     }
 
-    const assignmentPlan = assignRoomsToGroups(
-      [
-        {
-          preference: "in_person",
-          dayOfWeek: validation.value.dayOfWeek,
-          meetStartTime: validation.value.meetStartTime,
-        },
-      ],
-      roomInventoryResult.rooms,
-      existingUsageResult.usage,
-      false,
-    );
+    if (input.roomId != null) {
+      const targetRoom = roomInventoryResult.rooms.find(
+        (room) => room.id === input.roomId,
+      );
+      if (!targetRoom) {
+        return { error: "Selected room not found." };
+      }
 
-    manualRoomId = assignmentPlan.assignments[0]?.roomId ?? null;
-    manualRoomOverbooked = assignmentPlan.assignments[0]?.overbooked ?? false;
+      if (!targetRoom.availableDays.includes(validation.value.dayOfWeek)) {
+        return { error: "Selected room is not available on the chosen day." };
+      }
+
+      const conflictingGroups = existingUsageResult.usage.filter(
+        (usage) =>
+          usage.roomId === input.roomId &&
+          usage.dayOfWeek === validation.value.dayOfWeek &&
+          usage.meetStartTime === validation.value.meetStartTime,
+      );
+
+      manualRoomId = targetRoom.id;
+      manualRoomOverbooked =
+        conflictingGroups.length + 1 >
+        (targetRoom.groupCapacity ?? DEFAULT_ROOM_GROUP_CAPACITY);
+    } else {
+      const assignmentPlan = assignRoomsToGroups(
+        [
+          {
+            preference: "in_person",
+            dayOfWeek: validation.value.dayOfWeek,
+            meetStartTime: validation.value.meetStartTime,
+          },
+        ],
+        roomInventoryResult.rooms,
+        existingUsageResult.usage,
+        false,
+      );
+
+      manualRoomId = assignmentPlan.assignments[0]?.roomId ?? null;
+      manualRoomOverbooked = assignmentPlan.assignments[0]?.overbooked ?? false;
+    }
   }
 
   const { data: currentMembers, error: currentMemberError } = await supabase

--- a/lib/group-management.ts
+++ b/lib/group-management.ts
@@ -10,6 +10,7 @@ export type ManualGroupFormInput = {
 
 export type ManualGroupInput = ManualGroupFormInput & {
   studentIds: string[];
+  roomId?: number | null;
   overrideWarnings?: boolean;
 };
 


### PR DESCRIPTION
The group edit view is now able to change the room for a group with in person preference. If the groups preference is remote the edit menu looks as it did before.