### PR TITLE
Agenda Automatic Date Adjuster

### DIFF
--- a/app/admin/agendas/action.ts
+++ b/app/admin/agendas/action.ts
@@ -162,3 +162,65 @@ export async function toggleAgenda(agendaId: number, enabled: boolean) {
 
   revalidatePath("/admin/agendas");
 }
+
+export async function applyDatesToActiveAgendas( 
+  semesterStartDate: string, 
+  semesterEndDate: string, 
+) {
+  const supabase = await createClient();
+
+  const semesterStart = new Date(`${semesterStartDate}T00:00:00`);
+  const semesterEnd = new Date(`${semesterEndDate}T00:00:00`);
+
+  if (Number.isNaN(semesterStart.getTime()) || Number.isNaN(semesterEnd.getTime())) {
+    throw new Error("Invalid semester dates.");
+  }
+
+  if (semesterEnd < semesterStart) {
+    throw new Error("Semester end date must be after semester start date.");
+  }
+
+  const { data: agendas, error} = await supabase
+    .from("agenda")
+    .select("id")
+    .eq("enabled", true)
+    .order("week", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load active agendas: ${error?.message}`);
+  }
+
+  const updates = agendas.map((agenda, index) => {
+    const start = new Date(`${semesterStartDate}T00:00:00`);
+    start.setDate(start.getDate() + index * 7);
+
+    const end = new Date(start);
+    end.setDate(end.getDate() + 6);
+
+    if (end > semesterEnd) {
+      throw new Error(`The number of active agendas surpasses the number of weeks in the date range you have provided.`)
+    }
+
+    return {
+      id: agenda.id,
+      start_date: start.toISOString().slice(0, 10),
+      end_date: end.toISOString().slice(0, 10),
+    };
+  });
+
+  for (const update of updates) {
+    const { error: updateError } = await supabase
+      .from("agenda")
+      .update({
+        start_date: update.start_date,
+        end_date: update.end_date,
+      })
+      .eq("id", update.id);
+
+    if (updateError) {
+      throw new Error(`Failed to update agenda dates: ${updateError?.message}`);
+    }
+  }
+
+  revalidatePath("/admin/agendas");
+}

--- a/components/admin/agenda-manager.tsx
+++ b/components/admin/agenda-manager.tsx
@@ -34,6 +34,7 @@ import {
   updateAgenda,
   reorderAgendas,
   toggleAgenda,
+  applyDatesToActiveAgendas,
 } from "@/app/admin/agendas/action";
 import { Button } from "@/components/ui/button";
 import {
@@ -166,6 +167,9 @@ export function AgendaManager({ agendas }: { agendas: Agenda[] }) {
   }, [agendas]);
 
   const [copyingId, setCopyingId] = useState<number | null>(null);
+
+  const [semesterStartDate, setSemesterStartDate] = useState("");
+  const [semesterEndDate, setSemesterEndDate] = useState("");
 
   const resetCreateForm = () => {
     setCreateTitle("");
@@ -335,12 +339,38 @@ export function AgendaManager({ agendas }: { agendas: Agenda[] }) {
     });
   };
 
+  const handleApplySemesterDates = () => {
+    setActionError(null);
+
+    if (!semesterStartDate || !semesterEndDate) {
+      setActionError("Semester start and end dates are both required.");
+      return;
+    }
+
+    startTransition(async () => {
+      try {
+        await applyDatesToActiveAgendas(semesterStartDate, semesterEndDate);
+        router.refresh();
+      } catch (error) {
+        setActionError(
+          error instanceof Error ? error.message : "Failed to apply semester dates.",
+        );
+      }
+    });
+  };
+
   function getDisplayWeek(agendas: Agenda[], agendaId: number) {
     const index = agendas
         .filter((agenda) => agenda.enabled)
         .findIndex((agenda) => agenda.id === agendaId);
 
     return index === -1 ? null : index + 1;
+  }
+
+  function addDays(dateString: string, days: number) {
+    const date = new Date(`${dateString}T00:00:00`);
+    date.setDate(date.getDate() + days);
+    return date.toISOString().slice(0, 10);
   }
 
   return (
@@ -353,6 +383,51 @@ export function AgendaManager({ agendas }: { agendas: Agenda[] }) {
           {actionError}
         </div>
       )}
+
+      <Card className="rounded-none">
+        <CardHeader>
+          <CardTitle>Automatic Date Adjuster</CardTitle>
+          <CardDescription>
+            Apply weekly date ranges to active agendas. This will update
+            all active agenda dates once.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid items-end gap-4 md:grid-cols-[11rem_11rem_auto]">
+            <div className="grid gap-2">
+              <Label htmlFor="semester-start-date">Semester Start</Label>
+              <Input
+                id="semester-start-date"
+                type="date"
+                value={semesterStartDate}
+                max={semesterEndDate ? addDays(semesterEndDate, -1) : undefined}
+                onChange={(e) => setSemesterStartDate(e.target.value)}
+                disabled={isPending}
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="semester-end-date">Semester End</Label>
+              <Input
+                id="semester-end-date"
+                type="date"
+                value={semesterEndDate}
+                min={semesterStartDate ? addDays(semesterStartDate, 1) : undefined}
+                onChange={(e) => setSemesterEndDate(e.target.value)}
+                disabled={isPending}
+              />
+            </div>
+
+            <Button
+              type="button"
+              onClick={handleApplySemesterDates}
+              disabled={isPending || !semesterStartDate || !semesterEndDate}
+            >
+              {isPending ? "Applying..." : "Apply to Active Agendas"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Collapsible create form */}
       {showCreateForm ? (


### PR DESCRIPTION
Added an `Automatic Date Adjuster` to the top of the `Agendas` page in `Admin View`. 
Dates for **ENABLED** agendas are adjusted automatically based on the dates selected. 
After pressing the `Apply to Active Agendas` button, manually editing dates works as usual and dates are not automatically changed again unless the button is pressed.