### PR TITLE
Update group member information formatting

### DIFF
--- a/app/student/(protected)/group/page.tsx
+++ b/app/student/(protected)/group/page.tsx
@@ -76,10 +76,6 @@ function formatPhoneNumber(phone: string) {
     return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
   }
 
-  if (digits.length === 11 && digits.startsWith("1")) {
-    return `+1 (${digits.slice(1, 4)}) ${digits.slice(4, 7)}-${digits.slice(7)}`
-  }
-
   return phone;
 }
 

--- a/app/student/(protected)/group/page.tsx
+++ b/app/student/(protected)/group/page.tsx
@@ -69,6 +69,20 @@ function formatTime(timeString: string) {
   return `${hour12}:${minStr} ${ampm}`;
 }
 
+function formatPhoneNumber(phone: string) {
+  const digits = phone.replace(/\D/g, "");
+
+  if (digits.length === 10) {
+    return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+  }
+
+  if (digits.length === 11 && digits.startsWith("1")) {
+    return `+1 (${digits.slice(1, 4)}) ${digits.slice(4, 7)}-${digits.slice(7)}`
+  }
+
+  return phone;
+}
+
 function getInitials(name: string | null) {
   if (!name) return "?";
   return (
@@ -419,12 +433,14 @@ export default async function GroupPage() {
                             {m.email ? (
                               <span className="truncate">{m.email}</span>
                             ) : null}
-                            {m.phone ? <span>{m.phone}</span> : null}
+                            {m.phone ? <span>{formatPhoneNumber(m.phone)}</span> : null}
                           </div>
                         ) : null}
 
                         {m.bio ? (
                           <p className="mt-2 text-sm leading-relaxed text-foreground/80">
+                            Bio:
+                            <br />
                             {m.bio}
                           </p>
                         ) : null}


### PR DESCRIPTION
Changes:
- Make phone number formatted (ex. (123) 456-7890 rather than 1234567890).
- Put "Bio: " next to the bio so users understand that's what the text below a groupmate's name is.